### PR TITLE
ignore jupyter notebook temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 
 # Compiled files
 dist
+
+# iPython notebook backups
+.ipynb_checkpoints

--- a/Dockerfile.data
+++ b/Dockerfile.data
@@ -1,0 +1,10 @@
+FROM jupyter/scipy-notebook:latest
+
+EXPOSE 8888
+ENV NODE_ENV development
+
+RUN conda install -c esri arcgis
+
+COPY ./requirements.txt /code/
+
+RUN pip install -r /code/requirements.txt

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ You first have to set the `FIREBASE_ADMIN_PRIVATE_KEY` environment variable. Ask
   docker-compose run --rm backend
 ```
 
+To run the backend for data manipulation and preparation with Jupyter notebooks on `localhost:8888`:
+
+```sh
+  docker-compose up data-preparation
+```
+
+This installs [ArcGIS API for Python](https://developers.arcgis.com/python/). If you need any other dependencies, add them to `requirements.txt` file and rebuild the docker image:
+
+```sh
+  docker-compose build data-preparation
+```
+
+
 ## Frontend Deployment
 
 Automated deployment is set up on CircleCI. If _master_ passes all tests, it will automatically be deployed to firebase hosting. If you want to deploy from local, you will first have to set the `$FIREBASE_TOKEN` environment env. Locally run `firebase login:ci` to obtain this token.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,16 @@ services:
       - "3005:80"
     environment:
       - FIREBASE_TOKEN
+
+  data-preparation:
+      image: data-preparation
+      build:
+        context: .
+        dockerfile: Dockerfile.data
+      command: start-notebook.sh --NotebookApp.token=''
+      ports:
+        - 8888:8889
+      volumes: 
+        - ./:/home/jovyan/work:rw
+      environment:
+        - PYTHONPATH=/home/jovyan/work


### PR DESCRIPTION
adds additional readme instructions

adds a docker for backend dev

It gives you Jupyter notebooks with scipy and arcgis API.


+@mjamei

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/project-noah/2)
<!-- Reviewable:end -->
